### PR TITLE
Update install-RAiSD-GSL.sh for new gsl

### DIFF
--- a/install-RAiSD-GSL.sh
+++ b/install-RAiSD-GSL.sh
@@ -1,11 +1,12 @@
-wget https://ftp.gnu.org/gnu/gsl/gsl-latest.tar.gz
+wget http://ftp.gnu.org/gnu/gsl/gsl-latest.tar.gz
 tar -xvzf gsl-latest.tar.gz
 curpath=$(pwd)
 mkdir gsl
-cd gsl-2.6
+cd gsl-*
 ./configure --prefix=$curpath/gsl && make && make install
 cd ..
 rm Makefile
 cp makefiles/Makefile.GSL Makefile
 make clean
 make
+cd source && ln -s ../gsl/include/gsl/ .


### PR DESCRIPTION
Adapts to the current version 2.7.1 of gsl, as well as possible future updates.